### PR TITLE
Guard against pre-installed rubymine

### DIFF
--- a/scripts/ruby.sh
+++ b/scripts/ruby.sh
@@ -8,7 +8,10 @@ rbenv global 2.3.1
 gem install bundler
 rbenv rehash
 
-brew cask install rubymine
+# guard against pre-installed rubymine
+if [ ! -e /Applications/RubyMine.app ]; then
+  brew cask install rubymine
+fi
 
 source ${MY_DIR}/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli


### PR DESCRIPTION
As discussed in email today, some images have rubymine installed.  I was not able to test this fully, as I have just set up my machine, but this should stop brew from throwing an error and the install script stopping.  

I am not sure if the ide configuration (bottom of ruby.sh) will succeed. 

